### PR TITLE
Removed call to the missing method `util.escapeMeasureName`

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ exports.JsonInfluxDbStream = require('./converter');
  */
 exports.convert = function convert (opts) {
   return util.generateLineProtocolString({
-    measurement: util.escapeMeasureName(opts.measurement),
+    measurement: opts.measurement,
     tags: util.generateTagString(opts.tags),
     fields: util.generateFieldString(opts.fields),
     ts: opts.ts

--- a/util.js
+++ b/util.js
@@ -52,7 +52,7 @@ exports.generateTagString = function (data, keys) {
       ret +=
         escapeChars(FIELD_TAG_REPLACERS, keys[i]) +
         '=' +
-        escapeChars(FIELD_TAG_REPLACERS, data[keys[i]]) +
+        escapeChars(FIELD_TAG_REPLACERS, data[keys[i]].toString()) +
         ',';
     }
 


### PR DESCRIPTION
That method doesn't exist, and the measurement is already being escaped in `util.generateLineProtocolString`